### PR TITLE
Flipper Network RPC Mobile Support

### DIFF
--- a/components/bridge/connection/device/fzero/impl/build.gradle.kts
+++ b/components/bridge/connection/device/fzero/impl/build.gradle.kts
@@ -32,6 +32,7 @@ commonDependencies {
     implementation(projects.components.bridge.connection.feature.screenstreaming.api)
     implementation(projects.components.bridge.connection.feature.update.api)
     implementation(projects.components.bridge.connection.feature.emulate.api)
+    implementation(projects.components.bridge.connection.feature.networkproxy.api)
 
     implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.immutable.collections)

--- a/components/bridge/connection/device/fzero/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/device/fzero/impl/utils/FZeroFeatureClassToEnumMapper.kt
+++ b/components/bridge/connection/device/fzero/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/device/fzero/impl/utils/FZeroFeatureClassToEnumMapper.kt
@@ -6,6 +6,7 @@ import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeature
 import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
 import com.flipperdevices.bridge.connection.feature.devicecolor.api.FDeviceColorFeatureApi
 import com.flipperdevices.bridge.connection.feature.emulate.api.FEmulateFeatureApi
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.FNetworkProxyFeatureApi
 import com.flipperdevices.bridge.connection.feature.getinfo.api.FGattInfoFeatureApi
 import com.flipperdevices.bridge.connection.feature.getinfo.api.FGetInfoFeatureApi
 import com.flipperdevices.bridge.connection.feature.protocolversion.api.FSdkVersionFeatureApi
@@ -49,6 +50,7 @@ object FZeroFeatureClassToEnumMapper {
             FDeviceFeature.SCREEN_UNLOCK -> FScreenUnlockFeatureApi::class
             FDeviceFeature.UPDATE -> FUpdateFeatureApi::class
             FDeviceFeature.EMULATE -> FEmulateFeatureApi::class
+            FDeviceFeature.NETWORK_PROXY -> FNetworkProxyFeatureApi::class
         }
     }
 

--- a/components/bridge/connection/feature/common/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/common/api/FDeviceFeature.kt
+++ b/components/bridge/connection/feature/common/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/common/api/FDeviceFeature.kt
@@ -20,7 +20,8 @@ enum class FDeviceFeature {
     SCREEN_STREAMING,
     SCREEN_UNLOCK,
     UPDATE,
-    EMULATE
+    EMULATE,
+    NETWORK_PROXY
 }
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/components/bridge/connection/feature/networkproxy/api/build.gradle.kts
+++ b/components/bridge/connection/feature/networkproxy/api/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+}
+
+android.namespace = "com.flipperdevices.bridge.connection.feature.networkproxy.api"
+
+commonDependencies {
+    implementation(projects.components.core.data)
+
+    implementation(projects.components.bridge.connection.feature.common.api)
+
+    implementation(libs.kotlin.coroutines)
+}

--- a/components/bridge/connection/feature/networkproxy/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/api/FNetworkProxyFeatureApi.kt
+++ b/components/bridge/connection/feature/networkproxy/api/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/api/FNetworkProxyFeatureApi.kt
@@ -1,0 +1,106 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.api
+
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
+import kotlinx.coroutines.flow.Flow
+
+enum class NetworkProtocol {
+    TCP,
+    UDP
+}
+
+enum class NetworkConnectionState {
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED,
+    ERROR
+}
+
+sealed class NetworkError {
+    data object None : NetworkError()
+    data object DnsFailed : NetworkError()
+    data object Timeout : NetworkError()
+    data object ConnectionRefused : NetworkError()
+    data object NetworkUnreachable : NetworkError()
+    data object HostUnreachable : NetworkError()
+    data object InvalidConnection : NetworkError()
+    data object NotConnected : NetworkError()
+    data object SendFailed : NetworkError()
+    data object ReceiveFailed : NetworkError()
+    data object MaxConnections : NetworkError()
+    data object InvalidProtocol : NetworkError()
+    data object InternalError : NetworkError()
+}
+
+data class NetworkConnection(
+    val connectionId: Int,
+    val state: NetworkConnectionState,
+    val error: NetworkError = NetworkError.None,
+    val resolvedIp: String? = null
+)
+
+data class SendResult(
+    val connectionId: Int,
+    val bytesSent: Int,
+    val error: NetworkError = NetworkError.None
+)
+
+data class ReceivedData(
+    val connectionId: Int,
+    val data: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as ReceivedData
+        return connectionId == other.connectionId && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = connectionId
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}
+
+interface FNetworkProxyFeatureApi : FDeviceFeatureApi {
+    /**
+     * Flow of received data from all connections.
+     * Data is pushed here when the remote server sends data.
+     */
+    fun receivedDataFlow(): Flow<ReceivedData>
+
+    /**
+     * Flow of connection state changes.
+     */
+    fun connectionStateFlow(): Flow<NetworkConnection>
+
+    /**
+     * Connect to a remote host.
+     * @param host The hostname or IP address
+     * @param port The port number (1-65535)
+     * @param protocol TCP or UDP
+     * @param timeoutMs Connection timeout in milliseconds
+     * @return Connection result with connection ID if successful
+     */
+    suspend fun connect(
+        host: String,
+        port: Int,
+        protocol: NetworkProtocol = NetworkProtocol.TCP,
+        timeoutMs: Int = 30000
+    ): Result<NetworkConnection>
+
+    /**
+     * Send data on an established connection.
+     * @param connectionId The connection ID from connect()
+     * @param data The data to send (max 512 bytes per call, will be chunked if larger)
+     * @return Result with bytes sent or error
+     */
+    suspend fun send(connectionId: Int, data: ByteArray): Result<SendResult>
+
+    /**
+     * Close a connection.
+     * @param connectionId The connection ID to close
+     * @return Result indicating success or error
+     */
+    suspend fun close(connectionId: Int): Result<Unit>
+}

--- a/components/bridge/connection/feature/networkproxy/impl/build.gradle.kts
+++ b/components/bridge/connection/feature/networkproxy/impl/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+    id("flipper.anvil-multiplatform")
+}
+
+android.namespace = "com.flipperdevices.bridge.connection.feature.networkproxy.impl"
+
+commonDependencies {
+    implementation(projects.components.bridge.connection.feature.networkproxy.api)
+
+    implementation(projects.components.core.di)
+    implementation(projects.components.core.log)
+    implementation(projects.components.core.ktx)
+
+    implementation(projects.components.bridge.connection.feature.common.api)
+    implementation(projects.components.bridge.connection.transport.common.api)
+    implementation(projects.components.bridge.connection.feature.rpc.api)
+    implementation(projects.components.bridge.connection.feature.rpc.model)
+
+    implementation(projects.components.bridge.connection.pbutils)
+
+    implementation(libs.kotlin.coroutines)
+}

--- a/components/bridge/connection/feature/networkproxy/impl/build.gradle.kts
+++ b/components/bridge/connection/feature/networkproxy/impl/build.gradle.kts
@@ -12,6 +12,7 @@ commonDependencies {
     implementation(projects.components.core.di)
     implementation(projects.components.core.log)
     implementation(projects.components.core.ktx)
+    implementation(projects.components.core.preference)
 
     implementation(projects.components.bridge.connection.feature.common.api)
     implementation(projects.components.bridge.connection.transport.common.api)
@@ -21,4 +22,10 @@ commonDependencies {
     implementation(projects.components.bridge.connection.pbutils)
 
     implementation(libs.kotlin.coroutines)
+}
+
+androidDependencies {
+    implementation(projects.components.core.activityholder)
+    implementation(projects.components.core.ui.res)
+    implementation(libs.androidx.core)
 }

--- a/components/bridge/connection/feature/networkproxy/impl/src/androidMain/AndroidManifest.xml
+++ b/components/bridge/connection/feature/networkproxy/impl/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
+    <application>
+        <service
+            android:name=".service.NetworkProxyForegroundService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false"
+            android:stopWithTask="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Network proxy for Flipper Zero device" />
+        </service>
+    </application>
+</manifest>

--- a/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
@@ -1,0 +1,56 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+import android.content.Context
+import com.flipperdevices.bridge.connection.feature.networkproxy.impl.service.NetworkProxyForegroundService
+import com.flipperdevices.core.activityholder.CurrentActivityHolder
+import com.flipperdevices.core.log.TaggedLogger
+import com.flipperdevices.core.log.info
+
+private val logger = TaggedLogger("NetworkProxyServiceController")
+
+actual object NetworkProxyServiceController {
+    @Volatile
+    private var cachedAppContext: Context? = null
+
+    private fun getContext(): Context? {
+        // Try cached context first
+        cachedAppContext?.let { return it }
+
+        // Try to get from current activity and cache it
+        val activity = CurrentActivityHolder.getCurrentActivity()
+        if (activity != null) {
+            cachedAppContext = activity.applicationContext
+            return cachedAppContext
+        }
+
+        return null
+    }
+
+    actual fun startService() {
+        val context = getContext()
+        if (context == null) {
+            logger.info { "Cannot start service: no context available" }
+            return
+        }
+        logger.info { "Starting foreground service" }
+        try {
+            NetworkProxyForegroundService.start(context)
+        } catch (e: Exception) {
+            logger.info { "Failed to start service: ${e.message}" }
+        }
+    }
+
+    actual fun stopService() {
+        val context = getContext()
+        if (context == null) {
+            logger.info { "Cannot stop service: no context available" }
+            return
+        }
+        logger.info { "Stopping foreground service" }
+        try {
+            NetworkProxyForegroundService.stop(context)
+        } catch (e: Exception) {
+            logger.info { "Failed to stop service: ${e.message}" }
+        }
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/service/NetworkProxyForegroundService.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/service/NetworkProxyForegroundService.kt
@@ -1,0 +1,77 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.service
+
+import android.app.ForegroundServiceStartNotAllowedException
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.flipperdevices.core.log.info
+
+class NetworkProxyForegroundService : Service(), LogTagProvider {
+    override val TAG = "NetworkProxyForegroundService"
+
+    override fun onCreate() {
+        super.onCreate()
+        info { "Service created" }
+        try {
+            startForeground(
+                NOTIFICATION_ID,
+                NetworkProxyNotificationHelper.buildNotification(applicationContext)
+            )
+        } catch (e: Exception) {
+            error(e) { "Failed to start foreground service" }
+            // On Android 12+, this can fail if started from background
+            // The service will still run but without foreground priority
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                e is ForegroundServiceStartNotAllowedException) {
+                // Stop self since we can't run as foreground
+                stopSelf()
+            }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        info { "Service received command: ${intent?.action}" }
+
+        when (intent?.action) {
+            ACTION_STOP -> {
+                info { "Stopping service" }
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            }
+        }
+
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        info { "Service destroyed" }
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 101
+        const val ACTION_STOP = "com.flipperdevices.networkproxy.STOP"
+
+        fun start(context: Context) {
+            val intent = Intent(context, NetworkProxyForegroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, NetworkProxyForegroundService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/service/NetworkProxyNotificationHelper.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/androidMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/service/NetworkProxyNotificationHelper.kt
@@ -1,0 +1,55 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.service
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.flipperdevices.bridge.connection.feature.networkproxy.impl.R
+import com.flipperdevices.core.ui.res.R as DesignSystem
+
+private const val NETWORK_PROXY_NOTIFICATION_CHANNEL = "network_proxy_channel"
+
+object NetworkProxyNotificationHelper {
+    fun buildNotification(context: Context): Notification {
+        createChannelIfNotYet(context)
+
+        val stopIntent = Intent(context, NetworkProxyForegroundService::class.java).apply {
+            action = NetworkProxyForegroundService.ACTION_STOP
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            context,
+            0,
+            stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(context, NETWORK_PROXY_NOTIFICATION_CHANNEL)
+            .setContentTitle(context.getString(R.string.network_proxy_notification_title))
+            .setContentText(context.getString(R.string.network_proxy_notification_desc))
+            .setSmallIcon(DesignSystem.drawable.ic_notification)
+            .setSilent(true)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .addAction(
+                DesignSystem.drawable.ic_close_icon,
+                context.getString(R.string.network_proxy_notification_stop),
+                stopPendingIntent
+            ).build()
+    }
+
+    private fun createChannelIfNotYet(context: Context) {
+        val notificationManager = NotificationManagerCompat.from(context)
+
+        val channel = NotificationChannelCompat.Builder(
+            NETWORK_PROXY_NOTIFICATION_CHANNEL,
+            NotificationManagerCompat.IMPORTANCE_LOW
+        ).setName(context.getString(R.string.network_proxy_channel_name))
+            .setDescription(context.getString(R.string.network_proxy_channel_desc))
+            .build()
+
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/androidMain/res/values/strings.xml
+++ b/components/bridge/connection/feature/networkproxy/impl/src/androidMain/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="network_proxy_notification_title">Network Proxy Active</string>
+    <string name="network_proxy_notification_desc">Flipper is using network through this device</string>
+    <string name="network_proxy_notification_stop">Stop</string>
+    <string name="network_proxy_channel_name">Network Proxy</string>
+    <string name="network_proxy_channel_desc">Shows when Flipper is using network proxy</string>
+</resources>

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureApiImpl.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureApiImpl.kt
@@ -1,0 +1,331 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.FNetworkProxyFeatureApi
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnection
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnectionState
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkError
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkProtocol
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.ReceivedData
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.SendResult
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
+import com.flipperdevices.core.ktx.jre.toThrowableFlow
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.info
+import com.flipperdevices.protobuf.Main
+import com.flipperdevices.protobuf.network.CloseRequest
+import com.flipperdevices.protobuf.network.ConnectRequest
+import com.flipperdevices.protobuf.network.ConnectionState
+import com.flipperdevices.protobuf.network.ErrorCode
+import com.flipperdevices.protobuf.network.Protocol
+import com.flipperdevices.protobuf.network.ReceiveData
+import com.flipperdevices.protobuf.network.SendRequest
+import com.flipperdevices.protobuf.network.StateChanged
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import okio.ByteString.Companion.toByteString
+
+private const val MAX_CHUNK_SIZE = 512
+
+class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
+    @Assisted private val rpcFeatureApi: FRpcFeatureApi,
+    @Assisted private val scope: CoroutineScope
+) : FNetworkProxyFeatureApi, LogTagProvider {
+    override val TAG = "FNetworkProxyFeatureApi"
+
+    private val socketManager = SocketManager(scope)
+
+    private val _receivedDataFlow = MutableSharedFlow<ReceivedData>(extraBufferCapacity = 64)
+    private val _connectionStateFlow = MutableSharedFlow<NetworkConnection>(extraBufferCapacity = 16)
+
+    init {
+        // Forward socket manager flows
+        socketManager.receivedDataFlow
+            .onEach { data ->
+                // Send received data to Flipper
+                sendReceivedDataToFlipper(data)
+                _receivedDataFlow.emit(data)
+            }
+            .launchIn(scope)
+
+        socketManager.connectionStateFlow
+            .onEach { connection ->
+                // Send state change to Flipper
+                sendStateChangedToFlipper(connection)
+                _connectionStateFlow.emit(connection)
+            }
+            .launchIn(scope)
+
+        // Listen for incoming requests from Flipper
+        rpcFeatureApi.notificationFlow()
+            .onEach { message -> handleFlipperMessage(message) }
+            .catch { e -> info { "Notification flow error: ${e.message}" } }
+            .launchIn(scope)
+    }
+
+    override fun receivedDataFlow(): Flow<ReceivedData> = _receivedDataFlow.asSharedFlow()
+
+    override fun connectionStateFlow(): Flow<NetworkConnection> = _connectionStateFlow.asSharedFlow()
+
+    override suspend fun connect(
+        host: String,
+        port: Int,
+        protocol: NetworkProtocol,
+        timeoutMs: Int
+    ): Result<NetworkConnection> {
+        info { "Connect request: $protocol to $host:$port" }
+        return socketManager.connect(host, port, protocol, timeoutMs, clientConnectionId = 0)
+    }
+
+    override suspend fun send(connectionId: Int, data: ByteArray): Result<SendResult> {
+        info { "Send request: ${data.size} bytes on connection $connectionId" }
+
+        // Chunk data if needed
+        if (data.size <= MAX_CHUNK_SIZE) {
+            return socketManager.send(connectionId, data)
+        }
+
+        var totalBytesSent = 0
+        var offset = 0
+        while (offset < data.size) {
+            val chunkSize = minOf(MAX_CHUNK_SIZE, data.size - offset)
+            val chunk = data.copyOfRange(offset, offset + chunkSize)
+            val result = socketManager.send(connectionId, chunk)
+            if (result.isFailure) {
+                return result
+            }
+            totalBytesSent += result.getOrNull()?.bytesSent ?: 0
+            offset += chunkSize
+        }
+
+        return Result.success(
+            SendResult(
+                connectionId = connectionId,
+                bytesSent = totalBytesSent
+            )
+        )
+    }
+
+    override suspend fun close(connectionId: Int): Result<Unit> {
+        info { "Close request: connection $connectionId" }
+        return socketManager.close(connectionId)
+    }
+
+    private suspend fun handleFlipperMessage(message: Main) {
+        when {
+            message.network_connect_request != null -> {
+                handleConnectRequest(message)
+            }
+            message.network_send_request != null -> {
+                handleSendRequest(message)
+            }
+            message.network_close_request != null -> {
+                handleCloseRequest(message)
+            }
+        }
+    }
+
+    private suspend fun handleConnectRequest(message: Main) {
+        val request = message.network_connect_request ?: return
+        val clientConnectionId = request.connection_id.toInt()
+        info { "Flipper connect request: ${request.host}:${request.port} (conn_id=$clientConnectionId)" }
+
+        val protocol = when (request.protocol) {
+            Protocol.UDP -> NetworkProtocol.UDP
+            else -> NetworkProtocol.TCP
+        }
+
+        val result = socketManager.connect(
+            host = request.host,
+            port = request.port.toInt(),
+            protocol = protocol,
+            timeoutMs = request.timeout_ms.toInt().takeIf { it > 0 } ?: 30000,
+            clientConnectionId = clientConnectionId
+        )
+
+        // Send response
+        val response = result.fold(
+            onSuccess = { conn ->
+                Main(
+                    command_id = message.command_id,
+                    network_connect_response = com.flipperdevices.protobuf.network.ConnectResponse(
+                        connection_id = conn.connectionId,
+                        state = ConnectionState.CONNECTED,
+                        error = ErrorCode.NONE,
+                        resolved_ip = conn.resolvedIp ?: ""
+                    )
+                )
+            },
+            onFailure = { e ->
+                val errorCode = when ((e as? NetworkProxyException)?.error) {
+                    NetworkError.DnsFailed -> ErrorCode.DNS_FAILED
+                    NetworkError.Timeout -> ErrorCode.TIMEOUT
+                    NetworkError.ConnectionRefused -> ErrorCode.CONNECTION_REFUSED
+                    NetworkError.NetworkUnreachable -> ErrorCode.NETWORK_UNREACHABLE
+                    NetworkError.HostUnreachable -> ErrorCode.HOST_UNREACHABLE
+                    NetworkError.MaxConnections -> ErrorCode.MAX_CONNECTIONS
+                    else -> ErrorCode.INTERNAL_ERROR
+                }
+                Main(
+                    command_id = message.command_id,
+                    network_connect_response = com.flipperdevices.protobuf.network.ConnectResponse(
+                        connection_id = 0,
+                        state = ConnectionState.ERROR,
+                        error = errorCode
+                    )
+                )
+            }
+        )
+
+        rpcFeatureApi.requestWithoutAnswer(response.wrapToRequest())
+    }
+
+    private suspend fun handleSendRequest(message: Main) {
+        val request = message.network_send_request ?: return
+        val connectionId = request.connection_id.toInt()
+        val data = request.data_.toByteArray()
+
+        info { "Flipper send request: ${data.size} bytes on connection $connectionId" }
+
+        val result = socketManager.send(connectionId, data)
+
+        val response = result.fold(
+            onSuccess = { sendResult ->
+                Main(
+                    command_id = message.command_id,
+                    network_send_response = com.flipperdevices.protobuf.network.SendResponse(
+                        connection_id = connectionId,
+                        bytes_sent = sendResult.bytesSent,
+                        error = ErrorCode.NONE
+                    )
+                )
+            },
+            onFailure = { e ->
+                val errorCode = when ((e as? NetworkProxyException)?.error) {
+                    NetworkError.InvalidConnection -> ErrorCode.INVALID_CONNECTION
+                    NetworkError.NotConnected -> ErrorCode.NOT_CONNECTED
+                    NetworkError.SendFailed -> ErrorCode.SEND_FAILED
+                    else -> ErrorCode.INTERNAL_ERROR
+                }
+                Main(
+                    command_id = message.command_id,
+                    network_send_response = com.flipperdevices.protobuf.network.SendResponse(
+                        connection_id = connectionId,
+                        bytes_sent = 0,
+                        error = errorCode
+                    )
+                )
+            }
+        )
+
+        rpcFeatureApi.requestWithoutAnswer(response.wrapToRequest())
+    }
+
+    private suspend fun handleCloseRequest(message: Main) {
+        val request = message.network_close_request ?: return
+        val connectionId = request.connection_id.toInt()
+
+        info { "Flipper close request: connection $connectionId" }
+
+        val result = socketManager.close(connectionId)
+
+        val response = result.fold(
+            onSuccess = {
+                Main(
+                    command_id = message.command_id,
+                    network_close_response = com.flipperdevices.protobuf.network.CloseResponse(
+                        connection_id = connectionId,
+                        error = ErrorCode.NONE
+                    )
+                )
+            },
+            onFailure = { e ->
+                val errorCode = when ((e as? NetworkProxyException)?.error) {
+                    NetworkError.InvalidConnection -> ErrorCode.INVALID_CONNECTION
+                    else -> ErrorCode.INTERNAL_ERROR
+                }
+                Main(
+                    command_id = message.command_id,
+                    network_close_response = com.flipperdevices.protobuf.network.CloseResponse(
+                        connection_id = connectionId,
+                        error = errorCode
+                    )
+                )
+            }
+        )
+
+        rpcFeatureApi.requestWithoutAnswer(response.wrapToRequest())
+    }
+
+    private suspend fun sendReceivedDataToFlipper(data: ReceivedData) {
+        // Chunk data if needed and send to Flipper
+        var offset = 0
+        while (offset < data.data.size) {
+            val chunkSize = minOf(MAX_CHUNK_SIZE, data.data.size - offset)
+            val chunk = data.data.copyOfRange(offset, offset + chunkSize)
+            val hasNext = offset + chunkSize < data.data.size
+
+            val message = Main(
+                has_next = hasNext,
+                network_receive_data = ReceiveData(
+                    connection_id = data.connectionId,
+                    data_ = chunk.toByteString()
+                )
+            )
+
+            rpcFeatureApi.requestWithoutAnswer(message.wrapToRequest())
+            offset += chunkSize
+        }
+    }
+
+    private suspend fun sendStateChangedToFlipper(connection: NetworkConnection) {
+        val state = when (connection.state) {
+            NetworkConnectionState.DISCONNECTED -> ConnectionState.DISCONNECTED
+            NetworkConnectionState.CONNECTING -> ConnectionState.CONNECTING
+            NetworkConnectionState.CONNECTED -> ConnectionState.CONNECTED
+            NetworkConnectionState.ERROR -> ConnectionState.ERROR
+        }
+
+        val error = when (connection.error) {
+            NetworkError.None -> ErrorCode.NONE
+            NetworkError.DnsFailed -> ErrorCode.DNS_FAILED
+            NetworkError.Timeout -> ErrorCode.TIMEOUT
+            NetworkError.ConnectionRefused -> ErrorCode.CONNECTION_REFUSED
+            NetworkError.NetworkUnreachable -> ErrorCode.NETWORK_UNREACHABLE
+            NetworkError.HostUnreachable -> ErrorCode.HOST_UNREACHABLE
+            NetworkError.InvalidConnection -> ErrorCode.INVALID_CONNECTION
+            NetworkError.NotConnected -> ErrorCode.NOT_CONNECTED
+            NetworkError.SendFailed -> ErrorCode.SEND_FAILED
+            NetworkError.ReceiveFailed -> ErrorCode.RECEIVE_FAILED
+            NetworkError.MaxConnections -> ErrorCode.MAX_CONNECTIONS
+            NetworkError.InvalidProtocol -> ErrorCode.INVALID_PROTOCOL
+            NetworkError.InternalError -> ErrorCode.INTERNAL_ERROR
+        }
+
+        val message = Main(
+            network_state_changed = StateChanged(
+                connection_id = connection.connectionId,
+                state = state,
+                error = error
+            )
+        )
+
+        rpcFeatureApi.requestWithoutAnswer(message.wrapToRequest())
+    }
+
+    @AssistedFactory
+    fun interface InternalFactory {
+        operator fun invoke(
+            rpcFeatureApi: FRpcFeatureApi,
+            scope: CoroutineScope
+        ): FNetworkProxyFeatureApiImpl
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureApiImpl.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureApiImpl.kt
@@ -1,5 +1,6 @@
 package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
 
+import androidx.datastore.core.DataStore
 import com.flipperdevices.bridge.connection.feature.networkproxy.api.FNetworkProxyFeatureApi
 import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnection
 import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnectionState
@@ -9,17 +10,15 @@ import com.flipperdevices.bridge.connection.feature.networkproxy.api.ReceivedDat
 import com.flipperdevices.bridge.connection.feature.networkproxy.api.SendResult
 import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
 import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
-import com.flipperdevices.core.ktx.jre.toThrowableFlow
+import com.flipperdevices.core.di.provideDelegate
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
+import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.protobuf.Main
-import com.flipperdevices.protobuf.network.CloseRequest
-import com.flipperdevices.protobuf.network.ConnectRequest
 import com.flipperdevices.protobuf.network.ConnectionState
 import com.flipperdevices.protobuf.network.ErrorCode
 import com.flipperdevices.protobuf.network.Protocol
 import com.flipperdevices.protobuf.network.ReceiveData
-import com.flipperdevices.protobuf.network.SendRequest
 import com.flipperdevices.protobuf.network.StateChanged
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -29,17 +28,23 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.job
 import okio.ByteString.Companion.toByteString
+import javax.inject.Provider
 
 private const val MAX_CHUNK_SIZE = 512
 
 class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
+    settingsStoreProvider: Provider<DataStore<Settings>>,
     @Assisted private val rpcFeatureApi: FRpcFeatureApi,
     @Assisted private val scope: CoroutineScope
 ) : FNetworkProxyFeatureApi, LogTagProvider {
     override val TAG = "FNetworkProxyFeatureApi"
+    private val settingsStore by settingsStoreProvider
 
     private val socketManager = SocketManager(scope)
 
@@ -47,6 +52,21 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
     private val _connectionStateFlow = MutableSharedFlow<NetworkConnection>(extraBufferCapacity = 16)
 
     init {
+        // Observe settings and start/stop foreground service when setting changes
+        settingsStore.data
+            .map { it.enable_network_proxy_service }
+            .distinctUntilChanged()
+            .onEach { enabled ->
+                if (enabled) {
+                    info { "Network proxy service enabled - starting foreground service" }
+                    NetworkProxyServiceController.startService()
+                } else {
+                    info { "Network proxy service disabled - stopping foreground service" }
+                    NetworkProxyServiceController.stopService()
+                }
+            }
+            .launchIn(scope)
+
         // Forward socket manager flows
         socketManager.receivedDataFlow
             .onEach { data ->
@@ -69,6 +89,12 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
             .onEach { message -> handleFlipperMessage(message) }
             .catch { e -> info { "Notification flow error: ${e.message}" } }
             .launchIn(scope)
+
+        // Stop foreground service when scope is cancelled (device disconnected)
+        scope.coroutineContext.job.invokeOnCompletion {
+            info { "Network proxy feature shutting down - stopping foreground service" }
+            NetworkProxyServiceController.stopService()
+        }
     }
 
     override fun receivedDataFlow(): Flow<ReceivedData> = _receivedDataFlow.asSharedFlow()
@@ -154,6 +180,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
         // Send response
         val response = result.fold(
             onSuccess = { conn ->
+                info { "Connect success: conn_id=$clientConnectionId -> ${conn.resolvedIp}" }
                 Main(
                     command_id = message.command_id,
                     network_connect_response = com.flipperdevices.protobuf.network.ConnectResponse(
@@ -174,6 +201,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
                     NetworkError.MaxConnections -> ErrorCode.MAX_CONNECTIONS
                     else -> ErrorCode.INTERNAL_ERROR
                 }
+                info { "Connect failed: conn_id=$clientConnectionId error=$errorCode (${e.message})" }
                 Main(
                     command_id = message.command_id,
                     network_connect_response = com.flipperdevices.protobuf.network.ConnectResponse(
@@ -185,6 +213,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
             }
         )
 
+        info { "Sending connect response for conn_id=$clientConnectionId" }
         rpcFeatureApi.requestWithoutAnswer(response.wrapToRequest())
     }
 
@@ -199,6 +228,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
 
         val response = result.fold(
             onSuccess = { sendResult ->
+                info { "Send success: conn_id=$connectionId bytes=${sendResult.bytesSent}" }
                 Main(
                     command_id = message.command_id,
                     network_send_response = com.flipperdevices.protobuf.network.SendResponse(
@@ -215,6 +245,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
                     NetworkError.SendFailed -> ErrorCode.SEND_FAILED
                     else -> ErrorCode.INTERNAL_ERROR
                 }
+                info { "Send failed: conn_id=$connectionId error=$errorCode" }
                 Main(
                     command_id = message.command_id,
                     network_send_response = com.flipperdevices.protobuf.network.SendResponse(
@@ -226,6 +257,7 @@ class FNetworkProxyFeatureApiImpl @AssistedInject constructor(
             }
         )
 
+        info { "Sending send response for conn_id=$connectionId" }
         rpcFeatureApi.requestWithoutAnswer(response.wrapToRequest())
     }
 

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureFactoryImpl.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyFeatureFactoryImpl.kt
@@ -1,0 +1,30 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeature
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureApi
+import com.flipperdevices.bridge.connection.feature.common.api.FDeviceFeatureQualifier
+import com.flipperdevices.bridge.connection.feature.common.api.FUnsafeDeviceFeatureApi
+import com.flipperdevices.bridge.connection.feature.rpc.api.FRpcFeatureApi
+import com.flipperdevices.bridge.connection.transport.common.api.FConnectedDeviceApi
+import com.flipperdevices.core.di.AppGraph
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@FDeviceFeatureQualifier(FDeviceFeature.NETWORK_PROXY)
+@ContributesMultibinding(AppGraph::class, FDeviceFeatureApi.Factory::class)
+class FNetworkProxyFeatureFactoryImpl @Inject constructor(
+    private val factory: FNetworkProxyFeatureApiImpl.InternalFactory
+) : FDeviceFeatureApi.Factory {
+    override suspend fun invoke(
+        unsafeFeatureDeviceApi: FUnsafeDeviceFeatureApi,
+        scope: CoroutineScope,
+        connectedDevice: FConnectedDeviceApi
+    ): FDeviceFeatureApi? {
+        val rpcApi = unsafeFeatureDeviceApi.getUnsafe(FRpcFeatureApi::class) ?: return null
+        return factory(
+            rpcFeatureApi = rpcApi,
+            scope = scope
+        )
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyOnDeviceReadyFactoryImpl.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/FNetworkProxyOnDeviceReadyFactoryImpl.kt
@@ -1,0 +1,33 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+import com.flipperdevices.bridge.connection.feature.common.api.FOnDeviceReadyFeatureApi
+import com.flipperdevices.bridge.connection.feature.common.api.FUnsafeDeviceFeatureApi
+import com.flipperdevices.bridge.connection.feature.common.api.getUnsafe
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.FNetworkProxyFeatureApi
+import com.flipperdevices.bridge.connection.transport.common.api.FConnectedDeviceApi
+import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.info
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@ContributesMultibinding(AppGraph::class, FOnDeviceReadyFeatureApi.Factory::class)
+class FNetworkProxyOnDeviceReadyFactoryImpl @Inject constructor() : FOnDeviceReadyFeatureApi.Factory, LogTagProvider {
+    override val TAG = "FNetworkProxyOnDeviceReadyFactory"
+
+    override suspend fun invoke(
+        unsafeFeatureDeviceApi: FUnsafeDeviceFeatureApi,
+        scope: CoroutineScope,
+        connectedDevice: FConnectedDeviceApi
+    ): FOnDeviceReadyFeatureApi? {
+        // Request the network proxy feature to ensure it's initialized
+        // This triggers its init block which sets up the notification listener
+        val networkProxy = unsafeFeatureDeviceApi.getUnsafe(FNetworkProxyFeatureApi::class)
+        info { "Network proxy feature initialized: ${networkProxy != null}" }
+
+        // Return null since we don't need to provide an actual FOnDeviceReadyFeatureApi
+        // We just needed to trigger initialization of the network proxy feature
+        return null
+    }
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
@@ -1,0 +1,6 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+expect object NetworkProxyServiceController {
+    fun startService()
+    fun stopService()
+}

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/SocketManager.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/SocketManager.kt
@@ -112,7 +112,8 @@ internal class SocketManager(
                         state = NetworkConnectionState.CONNECTED,
                         resolvedIp = resolvedIp
                     )
-                    _connectionStateFlow.emit(networkConnection)
+                    // Don't emit to connectionStateFlow here - the response is sent directly
+                    // The flow is only for async state changes (disconnection, errors)
                     Result.success(networkConnection)
                 }
 
@@ -136,7 +137,7 @@ internal class SocketManager(
                         state = NetworkConnectionState.CONNECTED,
                         resolvedIp = resolvedIp
                     )
-                    _connectionStateFlow.emit(networkConnection)
+                    // Don't emit to connectionStateFlow here - the response is sent directly
                     Result.success(networkConnection)
                 }
             }
@@ -201,19 +202,15 @@ internal class SocketManager(
         info { "Closing connection $connectionId" }
 
         try {
-            connection.receiverJob?.cancelAndJoin()
+            // Cancel receiver job (don't wait - socket close will unblock it)
+            connection.receiverJob?.cancel()
+            // Close socket - this will cause blocked reads to throw and receiver to exit
             when (connection) {
                 is ManagedConnection.Tcp -> connection.socket.close()
                 is ManagedConnection.Udp -> connection.socket.close()
             }
-
-            _connectionStateFlow.emit(
-                NetworkConnection(
-                    connectionId = connectionId,
-                    state = NetworkConnectionState.DISCONNECTED
-                )
-            )
-
+            // Don't emit to connectionStateFlow - the response is sent directly
+            // The flow is only for async disconnections (remote side closing)
             Result.success(Unit)
         } catch (e: Exception) {
             error(e) { "Error closing connection $connectionId" }

--- a/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/SocketManager.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/SocketManager.kt
@@ -1,0 +1,342 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnection
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkConnectionState
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkError
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.NetworkProtocol
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.ReceivedData
+import com.flipperdevices.bridge.connection.feature.networkproxy.api.SendResult
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.flipperdevices.core.log.info
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketException
+import java.net.UnknownHostException
+
+private const val MAX_CONNECTIONS = 8
+private const val RECEIVE_BUFFER_SIZE = 512
+private const val UDP_RECEIVE_BUFFER_SIZE = 65535
+
+internal class SocketManager(
+    private val scope: CoroutineScope
+) : LogTagProvider {
+    override val TAG = "SocketManager"
+
+    private val connections = mutableMapOf<Int, ManagedConnection>()
+    private var nextConnectionId = 0
+
+    private val _receivedDataFlow = MutableSharedFlow<ReceivedData>(extraBufferCapacity = 64)
+    val receivedDataFlow: SharedFlow<ReceivedData> = _receivedDataFlow.asSharedFlow()
+
+    private val _connectionStateFlow = MutableSharedFlow<NetworkConnection>(extraBufferCapacity = 16)
+    val connectionStateFlow: SharedFlow<NetworkConnection> = _connectionStateFlow.asSharedFlow()
+
+    suspend fun connect(
+        host: String,
+        port: Int,
+        protocol: NetworkProtocol,
+        timeoutMs: Int,
+        clientConnectionId: Int
+    ): Result<NetworkConnection> = withContext(Dispatchers.IO) {
+        if (connections.size >= MAX_CONNECTIONS) {
+            return@withContext Result.failure(
+                NetworkProxyException(NetworkError.MaxConnections)
+            )
+        }
+
+        // Use the client-provided connection ID
+        val connectionId = if (clientConnectionId > 0) clientConnectionId else ++nextConnectionId
+        info { "Connecting $connectionId: $protocol to $host:$port (timeout: ${timeoutMs}ms)" }
+
+        try {
+            val resolvedAddress = try {
+                InetAddress.getByName(host)
+            } catch (e: UnknownHostException) {
+                error(e) { "DNS resolution failed for $host" }
+                return@withContext Result.failure(
+                    NetworkProxyException(NetworkError.DnsFailed)
+                )
+            }
+
+            val resolvedIp = resolvedAddress.hostAddress
+
+            when (protocol) {
+                NetworkProtocol.TCP -> {
+                    val socket = Socket()
+                    val connectResult = withTimeoutOrNull(timeoutMs.toLong()) {
+                        try {
+                            socket.connect(InetSocketAddress(resolvedAddress, port), timeoutMs)
+                            true
+                        } catch (e: IOException) {
+                            error(e) { "TCP connection failed to $host:$port" }
+                            false
+                        }
+                    }
+
+                    if (connectResult != true) {
+                        socket.close()
+                        return@withContext Result.failure(
+                            NetworkProxyException(NetworkError.Timeout)
+                        )
+                    }
+
+                    val connection = ManagedConnection.Tcp(
+                        id = connectionId,
+                        socket = socket,
+                        host = host,
+                        port = port,
+                        resolvedIp = resolvedIp
+                    )
+                    connections[connectionId] = connection
+                    startTcpReceiver(connection)
+
+                    val networkConnection = NetworkConnection(
+                        connectionId = connectionId,
+                        state = NetworkConnectionState.CONNECTED,
+                        resolvedIp = resolvedIp
+                    )
+                    _connectionStateFlow.emit(networkConnection)
+                    Result.success(networkConnection)
+                }
+
+                NetworkProtocol.UDP -> {
+                    val socket = DatagramSocket()
+                    socket.connect(resolvedAddress, port)
+
+                    val connection = ManagedConnection.Udp(
+                        id = connectionId,
+                        socket = socket,
+                        remoteAddress = resolvedAddress,
+                        remotePort = port,
+                        host = host,
+                        resolvedIp = resolvedIp
+                    )
+                    connections[connectionId] = connection
+                    startUdpReceiver(connection)
+
+                    val networkConnection = NetworkConnection(
+                        connectionId = connectionId,
+                        state = NetworkConnectionState.CONNECTED,
+                        resolvedIp = resolvedIp
+                    )
+                    _connectionStateFlow.emit(networkConnection)
+                    Result.success(networkConnection)
+                }
+            }
+        } catch (e: Exception) {
+            error(e) { "Connection failed" }
+            Result.failure(NetworkProxyException(NetworkError.InternalError))
+        }
+    }
+
+    suspend fun send(connectionId: Int, data: ByteArray): Result<SendResult> = withContext(Dispatchers.IO) {
+        val connection = connections[connectionId]
+            ?: return@withContext Result.failure(
+                NetworkProxyException(NetworkError.InvalidConnection)
+            )
+
+        try {
+            when (connection) {
+                is ManagedConnection.Tcp -> {
+                    if (connection.socket.isClosed || !connection.socket.isConnected) {
+                        return@withContext Result.failure(
+                            NetworkProxyException(NetworkError.NotConnected)
+                        )
+                    }
+                    connection.socket.getOutputStream().write(data)
+                    connection.socket.getOutputStream().flush()
+                }
+
+                is ManagedConnection.Udp -> {
+                    if (connection.socket.isClosed) {
+                        return@withContext Result.failure(
+                            NetworkProxyException(NetworkError.NotConnected)
+                        )
+                    }
+                    val packet = DatagramPacket(
+                        data,
+                        data.size,
+                        connection.remoteAddress,
+                        connection.remotePort
+                    )
+                    connection.socket.send(packet)
+                }
+            }
+
+            Result.success(
+                SendResult(
+                    connectionId = connectionId,
+                    bytesSent = data.size
+                )
+            )
+        } catch (e: IOException) {
+            error(e) { "Send failed on connection $connectionId" }
+            Result.failure(NetworkProxyException(NetworkError.SendFailed))
+        }
+    }
+
+    suspend fun close(connectionId: Int): Result<Unit> = withContext(Dispatchers.IO) {
+        val connection = connections.remove(connectionId)
+            ?: return@withContext Result.failure(
+                NetworkProxyException(NetworkError.InvalidConnection)
+            )
+
+        info { "Closing connection $connectionId" }
+
+        try {
+            connection.receiverJob?.cancelAndJoin()
+            when (connection) {
+                is ManagedConnection.Tcp -> connection.socket.close()
+                is ManagedConnection.Udp -> connection.socket.close()
+            }
+
+            _connectionStateFlow.emit(
+                NetworkConnection(
+                    connectionId = connectionId,
+                    state = NetworkConnectionState.DISCONNECTED
+                )
+            )
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            error(e) { "Error closing connection $connectionId" }
+            Result.success(Unit) // Still consider it closed
+        }
+    }
+
+    fun closeAll() {
+        connections.keys.toList().forEach { connectionId ->
+            scope.launch {
+                close(connectionId)
+            }
+        }
+    }
+
+    private fun startTcpReceiver(connection: ManagedConnection.Tcp) {
+        connection.receiverJob = scope.launch(Dispatchers.IO) {
+            val buffer = ByteArray(RECEIVE_BUFFER_SIZE)
+            try {
+                val inputStream = connection.socket.getInputStream()
+                while (isActive && !connection.socket.isClosed) {
+                    val bytesRead = inputStream.read(buffer)
+                    if (bytesRead == -1) {
+                        // Connection closed by remote
+                        info { "TCP connection ${connection.id} closed by remote" }
+                        break
+                    }
+                    if (bytesRead > 0) {
+                        val data = buffer.copyOf(bytesRead)
+                        _receivedDataFlow.emit(
+                            ReceivedData(
+                                connectionId = connection.id,
+                                data = data
+                            )
+                        )
+                    }
+                }
+            } catch (e: SocketException) {
+                if (isActive) {
+                    info { "TCP socket ${connection.id} closed: ${e.message}" }
+                }
+            } catch (e: IOException) {
+                if (isActive) {
+                    error(e) { "TCP receive error on connection ${connection.id}" }
+                }
+            } finally {
+                if (connections.containsKey(connection.id)) {
+                    connections.remove(connection.id)
+                    _connectionStateFlow.emit(
+                        NetworkConnection(
+                            connectionId = connection.id,
+                            state = NetworkConnectionState.DISCONNECTED
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun startUdpReceiver(connection: ManagedConnection.Udp) {
+        connection.receiverJob = scope.launch(Dispatchers.IO) {
+            val buffer = ByteArray(UDP_RECEIVE_BUFFER_SIZE)
+            try {
+                while (isActive && !connection.socket.isClosed) {
+                    val packet = DatagramPacket(buffer, buffer.size)
+                    connection.socket.receive(packet)
+                    if (packet.length > 0) {
+                        val data = buffer.copyOf(packet.length)
+                        _receivedDataFlow.emit(
+                            ReceivedData(
+                                connectionId = connection.id,
+                                data = data
+                            )
+                        )
+                    }
+                }
+            } catch (e: SocketException) {
+                if (isActive) {
+                    info { "UDP socket ${connection.id} closed: ${e.message}" }
+                }
+            } catch (e: IOException) {
+                if (isActive) {
+                    error(e) { "UDP receive error on connection ${connection.id}" }
+                }
+            } finally {
+                if (connections.containsKey(connection.id)) {
+                    connections.remove(connection.id)
+                    _connectionStateFlow.emit(
+                        NetworkConnection(
+                            connectionId = connection.id,
+                            state = NetworkConnectionState.DISCONNECTED
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+private sealed class ManagedConnection {
+    abstract val id: Int
+    abstract var receiverJob: Job?
+
+    data class Tcp(
+        override val id: Int,
+        val socket: Socket,
+        val host: String,
+        val port: Int,
+        val resolvedIp: String?
+    ) : ManagedConnection() {
+        override var receiverJob: Job? = null
+    }
+
+    data class Udp(
+        override val id: Int,
+        val socket: DatagramSocket,
+        val remoteAddress: InetAddress,
+        val remotePort: Int,
+        val host: String,
+        val resolvedIp: String?
+    ) : ManagedConnection() {
+        override var receiverJob: Job? = null
+    }
+}
+
+class NetworkProxyException(val error: NetworkError) : Exception("Network proxy error: $error")

--- a/components/bridge/connection/feature/networkproxy/impl/src/desktopMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
+++ b/components/bridge/connection/feature/networkproxy/impl/src/desktopMain/kotlin/com/flipperdevices/bridge/connection/feature/networkproxy/impl/api/NetworkProxyServiceController.kt
@@ -1,0 +1,11 @@
+package com.flipperdevices.bridge.connection.feature.networkproxy.impl.api
+
+actual object NetworkProxyServiceController {
+    actual fun startService() {
+        // No-op on desktop - no foreground service needed
+    }
+
+    actual fun stopService() {
+        // No-op on desktop
+    }
+}

--- a/components/bridge/connection/feature/rpc/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/rpc/impl/FProtobufMessageCollector.kt
+++ b/components/bridge/connection/feature/rpc/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/rpc/impl/FProtobufMessageCollector.kt
@@ -71,7 +71,9 @@ class FProtobufMessageCollector @AssistedInject constructor(
             while (isActive) {
                 val request = requestStorage.getNextRequest()
                 if (request != null) {
-                    serialApi.sendBytes(request.data.encodeWithDelimitedSize())
+                    val bytes = request.data.encodeWithDelimitedSize()
+                    info { "Sending ${bytes.size} bytes, cmd_id=${request.data.command_id}" }
+                    serialApi.sendBytes(bytes)
                     runCatching {
                         request.onSendCallback?.invoke()
                     }.onFailure {

--- a/components/bridge/connection/feature/rpc/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorage.kt
+++ b/components/bridge/connection/feature/rpc/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorage.kt
@@ -3,60 +3,77 @@ package com.flipperdevices.bridge.connection.feature.rpc.storage
 import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequest
 import com.flipperdevices.core.log.LogTagProvider
 import com.flipperdevices.core.log.info
-import java.util.concurrent.PriorityBlockingQueue
-import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.channels.Channel
+import java.util.PriorityQueue
 import javax.inject.Inject
 
 private const val QUEUE_INITIAL_CAPACITY = 11
-private const val REQUEST_POOL_TIMEOUT_MS = 100L
 
 class FRequestStorage @Inject constructor() : LogTagProvider {
     override val TAG = "FlipperRequestStorage"
-    private val queue = PriorityBlockingQueue(
+    private val lock = Any()
+    private val queue = PriorityQueue(
         QUEUE_INITIAL_CAPACITY,
         FRequestComparator()
     )
+    // Channel to signal when new requests are available
+    private val requestSignal = Channel<Unit>(Channel.CONFLATED)
 
     fun sendRequest(vararg requests: FlipperRequest) {
-        queue.addAll(requests)
-        info { "Add new request. New request storage size: ${queue.size}" }
+        synchronized(lock) {
+            queue.addAll(requests)
+            info { "Add new request. New request storage size: ${queue.size}" }
+        }
+        // Signal that requests are available (non-blocking, conflated)
+        requestSignal.trySend(Unit)
     }
 
     fun removeRequest(request: FlipperRequest) {
-        val isRemoved = queue.remove(request)
-        if (isRemoved) {
-            info { "Remove request ($isRemoved). New request storage size: ${queue.size}" }
+        synchronized(lock) {
+            val isRemoved = queue.remove(request)
+            if (isRemoved) {
+                info { "Remove request ($isRemoved). New request storage size: ${queue.size}" }
+            }
         }
     }
 
     fun removeIf(filter: (FlipperRequest) -> Boolean) {
-        info {
-            "Start remove from storage by filter. Current request storage size is ${queue.size}"
-        }
-        val notDeletedRequests = mutableListOf<FlipperRequest>()
-        while (!queue.isEmpty()) {
-            val request = queue.poll() ?: continue
-            if (!filter(request)) {
-                notDeletedRequests.add(request)
-            } else {
-                info { "Found request for deleted by filter and delete it" }
+        synchronized(lock) {
+            info {
+                "Start remove from storage by filter. Current request storage size is ${queue.size}"
             }
-        }
-        queue.addAll(notDeletedRequests)
-        info {
-            "Finish remove from storage by filter. Current request storage size is ${queue.size}"
+            val notDeletedRequests = mutableListOf<FlipperRequest>()
+            while (queue.isNotEmpty()) {
+                val request = queue.poll() ?: continue
+                if (!filter(request)) {
+                    notDeletedRequests.add(request)
+                } else {
+                    info { "Found request for deleted by filter and delete it" }
+                }
+            }
+            queue.addAll(notDeletedRequests)
+            info {
+                "Finish remove from storage by filter. Current request storage size is ${queue.size}"
+            }
         }
     }
 
-    fun getNextRequest(timeout: Long = REQUEST_POOL_TIMEOUT_MS): FlipperRequest? {
-        val request = runCatching {
-            queue.poll(timeout, TimeUnit.MILLISECONDS)
-        }.getOrNull()
-
-        if (request != null) {
-            info { "Remove request from queue and new queue size is ${queue.size}" }
+    /**
+     * Suspends until a request is available, then returns it.
+     * This is efficient - no polling, true coroutine suspension.
+     */
+    suspend fun getNextRequest(): FlipperRequest? {
+        while (true) {
+            // Try to get from queue first
+            val request = synchronized(lock) {
+                queue.poll()
+            }
+            if (request != null) {
+                info { "Remove request from queue and new queue size is ${queue.size}" }
+                return request
+            }
+            // Queue was empty, suspend until signaled
+            requestSignal.receive()
         }
-
-        return request
     }
 }

--- a/components/bridge/connection/feature/rpc/impl/src/jvmSharedTest/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorageTest.kt
+++ b/components/bridge/connection/feature/rpc/impl/src/jvmSharedTest/kotlin/com/flipperdevices/bridge/connection/feature/rpc/storage/FRequestStorageTest.kt
@@ -4,7 +4,10 @@ import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequest
 import com.flipperdevices.bridge.connection.feature.rpc.model.FlipperRequestPriority
 import com.flipperdevices.bridge.connection.feature.rpc.model.wrapToRequest
 import com.flipperdevices.protobuf.Main
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -26,9 +29,9 @@ class FRequestStorageTest {
 
         subject.sendRequest(mediumPriority, lowPriority, highestPriority)
 
-        assertEquals(highestPriority, subject.getNextRequest(timeout = 100))
-        assertEquals(mediumPriority, subject.getNextRequest(timeout = 100))
-        assertEquals(lowPriority, subject.getNextRequest(timeout = 100))
+        assertEquals(highestPriority, subject.getNextRequest())
+        assertEquals(mediumPriority, subject.getNextRequest())
+        assertEquals(lowPriority, subject.getNextRequest())
     }
 
     @Test
@@ -39,18 +42,45 @@ class FRequestStorageTest {
 
         subject.sendRequest(mediumPriority, lowPriority, highestPriority)
 
-        assertEquals(highestPriority, subject.getNextRequest(timeout = 100))
-        assertEquals(mediumPriority, subject.getNextRequest(timeout = 100))
-        assertEquals(lowPriority, subject.getNextRequest(timeout = 100))
+        assertEquals(highestPriority, subject.getNextRequest())
+        assertEquals(mediumPriority, subject.getNextRequest())
+        assertEquals(lowPriority, subject.getNextRequest())
     }
 
     @Test
-    fun `Return null if not present request`() = runBlocking {
+    fun `Suspends when queue is empty`() = runBlocking {
         val request = Main().wrapToRequest(FlipperRequestPriority.BACKGROUND)
 
         subject.sendRequest(request)
 
-        assertEquals(request, subject.getNextRequest(timeout = 100))
-        assertNull(subject.getNextRequest(timeout = 100))
+        assertEquals(request, subject.getNextRequest())
+
+        // getNextRequest should suspend when queue is empty
+        // Use timeout to verify it doesn't return immediately
+        val result = withTimeoutOrNull(100) {
+            subject.getNextRequest()
+        }
+        assertNull(result)
+    }
+
+    @Test
+    fun `Resumes when request is added`() = runBlocking {
+        val request = Main().wrapToRequest(FlipperRequestPriority.BACKGROUND)
+
+        // Start waiting for request in background
+        val deferred = async {
+            subject.getNextRequest()
+        }
+
+        // Give it time to start suspending
+        delay(50)
+
+        // Add request - should resume the suspended coroutine
+        subject.sendRequest(request)
+
+        val result = withTimeoutOrNull(100) {
+            deferred.await()
+        }
+        assertEquals(request, result)
     }
 }

--- a/components/bridge/connection/feature/storage/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/storage/impl/fm/download/ReaderRequestLooper.kt
+++ b/components/bridge/connection/feature/storage/impl/src/commonMain/kotlin/com/flipperdevices/bridge/connection/feature/storage/impl/fm/download/ReaderRequestLooper.kt
@@ -10,9 +10,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
 import okio.Closeable
 
 class ReaderRequestLooper(
@@ -44,15 +45,21 @@ class ReaderRequestLooper(
     }
 
     /**
-     * Implementation like this is required because after coroutine
-     * is cancelled, the queue.receive() will lasts forever
+     * Get next byte pack from queue with proper cancellation support.
+     * Uses select to wait for either data OR scope cancellation without busy-waiting.
      */
     suspend fun getNextBytePack(): Main {
-        while (scope.isActive) {
-            val value = queue.tryReceive().getOrNull()
-            if (value != null) return value
+        return select {
+            queue.onReceiveCatching { result ->
+                if (result.isClosed) {
+                    throw result.exceptionOrNull() ?: CancellationException("Channel closed")
+                }
+                result.getOrThrow()
+            }
+            scope.coroutineContext.job.onJoin {
+                throw CancellationException("Scope cancelled while waiting for byte pack")
+            }
         }
-        throw CancellationException("Scope got cancelled during getting next byte pack")
     }
 
     override fun close() {

--- a/components/core/preference/src/commonMain/proto/settings.proto
+++ b/components/core/preference/src/commonMain/proto/settings.proto
@@ -76,4 +76,5 @@ message Settings {
   bool show_hidden_files_on_flipper = 32;
   bool disabled_vibration = 33;
   bool infrared_remotes_tab_shown = 34;
+  bool enable_network_proxy_service = 35;
 }

--- a/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
+++ b/components/faphub/installation/manifest/impl/src/main/java/com/flipperdevices/faphub/installation/manifest/impl/utils/FapManifestsLoader.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -80,23 +79,27 @@ class FapManifestsLoader @AssistedInject constructor(
             }
             fStorageInfoApi.invalidate(scope = scope)
 
-            combine(
+            // Wait for storage info to be ready (not InProgress) - use first{} to avoid infinite loop
+            val (connectionState, flipperStorageInformation) = combine(
                 fDeviceOrchestrator.getState(),
                 fStorageInfoApi.getStorageInformationFlow()
             ) { connectionState, flipperStorageInformation ->
                 connectionState to flipperStorageInformation
-            }.collectLatest { (connectionState, flipperStorageInformation) ->
-                runCatching {
-                    loadInternal(
-                        connectionState = connectionState,
-                        storageInformation = flipperStorageInformation
-                    )
-                }.onFailure {
-                    if (it is CancellationException) {
-                        throw it
-                    } else {
-                        manifestLoaderState.emit(FapManifestLoaderState.Failed(it))
-                    }
+            }.first { (_, storageInfo) ->
+                // Wait until external storage status is Ready (not InProgress)
+                storageInfo.externalStorageStatus is FlipperInformationStatus.Ready<*>
+            }
+
+            runCatching {
+                loadInternal(
+                    connectionState = connectionState,
+                    storageInformation = flipperStorageInformation
+                )
+            }.onFailure {
+                if (it is CancellationException) {
+                    throw it
+                } else {
+                    manifestLoaderState.emit(FapManifestLoaderState.Failed(it))
                 }
             }
         }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/ComposableSettings.kt
@@ -80,6 +80,7 @@ fun ComposableSettings(
             ExperimentalCategory(
                 settings = settings,
                 onSwitchExperimental = settingsViewModel::onSwitchExperimental,
+                onSwitchNetworkProxyService = settingsViewModel::onSwitchNetworkProxyService,
                 onOpenFM = { onOpen(SettingsNavigationConfig.FileManager) },
             )
             ExportKeysCategory(

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/category/ExperimentalCategory.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/composable/category/ExperimentalCategory.kt
@@ -6,12 +6,14 @@ import com.flipperdevices.core.preference.pb.Settings
 import com.flipperdevices.settings.impl.R
 import com.flipperdevices.settings.impl.composable.components.CategoryElement
 import com.flipperdevices.settings.impl.composable.components.ClickableElement
+import com.flipperdevices.settings.impl.composable.components.SwitchableElement
 
 @Composable
 fun ExperimentalCategory(
     settings: Settings,
     onOpenFM: () -> Unit,
     onSwitchExperimental: (Boolean) -> Unit,
+    onSwitchNetworkProxyService: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     CardCategory(modifier = modifier) {
@@ -26,6 +28,12 @@ fun ExperimentalCategory(
                 titleId = R.string.experimental_file_manager,
                 descriptionId = R.string.experimental_file_manager_desc,
                 onClick = onOpenFM
+            )
+            SwitchableElement(
+                titleId = R.string.experimental_network_proxy_service,
+                descriptionId = R.string.experimental_network_proxy_service_desc,
+                state = settings.enable_network_proxy_service,
+                onSwitchState = onSwitchNetworkProxyService
             )
         }
     }

--- a/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/SettingsViewModel.kt
+++ b/components/settings/impl/src/main/java/com/flipperdevices/settings/impl/viewmodels/SettingsViewModel.kt
@@ -110,4 +110,14 @@ class SettingsViewModel @Inject constructor(
             }
         }
     }
+
+    fun onSwitchNetworkProxyService(value: Boolean) {
+        viewModelScope.launch {
+            dataStoreSettings.updateData {
+                it.copy(
+                    enable_network_proxy_service = value
+                )
+            }
+        }
+    }
 }

--- a/components/settings/impl/src/main/res/values/strings.xml
+++ b/components/settings/impl/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="experimental_screen_streaming">Screen Streaming</string>
     <string name="experimental_screen_streaming_desc">Control Flipper via phone</string>
     <string name="experimental_application_catalog">Enable Apps in Hub</string>
+    <string name="experimental_network_proxy_service">Network Proxy Service</string>
+    <string name="experimental_network_proxy_service_desc">Keep network proxy active when app is backgrounded</string>
 
     <string name="other_github_open">GitHub</string>
     <string name="other_github_url">https://github.com/flipperdevices/Flipper-Android-App</string>

--- a/instances/android/app/build.gradle.kts
+++ b/instances/android/app/build.gradle.kts
@@ -207,6 +207,8 @@ dependencies {
     implementation(projects.components.bridge.connection.feature.update.impl)
     implementation(projects.components.bridge.connection.feature.emulate.api)
     implementation(projects.components.bridge.connection.feature.emulate.impl)
+    implementation(projects.components.bridge.connection.feature.networkproxy.api)
+    implementation(projects.components.bridge.connection.feature.networkproxy.impl)
 
     implementation(projects.components.analytics.shake2report.api)
     if (IS_SENTRY_ENABLED) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -93,6 +93,8 @@ include(
     ":components:bridge:connection:feature:update:impl",
     ":components:bridge:connection:feature:emulate:api",
     ":components:bridge:connection:feature:emulate:impl",
+    ":components:bridge:connection:feature:networkproxy:api",
+    ":components:bridge:connection:feature:networkproxy:impl",
 
     ":components:filemngr:util",
     ":components:filemanager:api",


### PR DESCRIPTION
This is PR 3/3 for Flipper Network API support.

**Background**

This PR is created to give Flipper Zero devices the ability to open TCP and UDP sockets, allowing them to make network requests.

**Changes**

* File syncing in the Android app is more efficient: Sync operations no longer get stuck, complete quicker, and avoid pegging the CPU at 100%.
* Having the Flipper app open allows the Flipper to use the network RPC API over Bluetooth when connected. This RPC interface is similar to a Socks5 proxy, allowing the Flipper to open TCP and UDP sockets in user applications.
* Added a new experimental option: Network Proxy Service. When enabled by the user, the network RPC API will continue to be available when the app is no longer in the foreground. This can be turned off in the app or stopped via its dedicated activity notification.

**Test plan**

* Once protobuf and firmware changes are merged, launch both the Example Network app in the firmware and the Android app. Test each menu option for TCP and UDP tests.
* Enable the Network Proxy Service under Experimental Options -- it is disabled by default. Background the Flipper Mobile App and verify connectivity persists using the Example Network app on the Flipper.
* Disable or stop the Network Proxy Service, confirm it is no longer active.
* Validate that the idle CPU usage of the Flipper app when the Network Proxy Service is running is 0%: `for i in {1..6}; do adb shell top -b -n 1 -p $(adb shell pidof com.flipperdevices.app) 2>/dev/null | grep -E "com.flipperdevices|%CPU" | head -2; sleep 3; done`

Expected idle result, example:
```
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 373M 155M S  0.0   2.4   0:09.61 com.flipperdevices.app
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 373M 155M S  0.0   2.4   0:09.62 com.flipperdevices.app
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 373M 155M S  0.0   2.4   0:09.63 com.flipperdevices.app
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 360M 155M S  0.0   2.3   0:09.65 com.flipperdevices.app
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 360M 155M S  3.5   2.3   0:09.65 com.flipperdevices.app
  PID USER         PR  NI VIRT  RES  SHR S[%CPU] %MEM     TIME+ ARGS
12872 u0_a398      20   0 9.2G 360M 155M S  0.0   2.3   0:09.66 com.flipperdevices.app
```
